### PR TITLE
BCE-10749: Upgrade RH Mainnet nodes to nitro-node:v3.11.0-rc.2-b4e3c3e

### DIFF
--- a/default.env
+++ b/default.env
@@ -34,5 +34,5 @@ ENV_VERSION=3
 # Robinhood Orbit chain. Set COMPOSE_FILE=robinhood.yml:ext-network.yml in .env to run.
 # Robinhood's parent chain is Ethereum L1, so PARENT_RPC and PARENT_BEACON must point at
 # Ethereum archive + beacon endpoints when running robinhood.yml.
-ROBINHOOD_NITRO_TAG=v3.10.0-b1cf6db
+ROBINHOOD_NITRO_TAG=v3.11.0-rc.2-b4e3c3e
 PARTNER_KEY=

--- a/robinhood.yml
+++ b/robinhood.yml
@@ -9,7 +9,7 @@ x-logging: &logging
 services:
   nitro:
     restart: "unless-stopped"
-    image: ${DOCKER_REPO:-offchainlabs/nitro-node}:${ROBINHOOD_NITRO_TAG:-v3.10.0-b1cf6db}
+    image: ${DOCKER_REPO:-offchainlabs/nitro-node}:${ROBINHOOD_NITRO_TAG:-v3.11.0-rc.2-b4e3c3e}
     stop_grace_period: 5m
     environment:
       - EXTRAS=${EXTRAS}


### PR DESCRIPTION
Upgrade Robinhood Mainnet nodes to nitro-node:v3.11.0-rc.2-b4e3c3e